### PR TITLE
Take into account current status bar visibility

### DIFF
--- a/LGAlertView/LGAlertViewController.m
+++ b/LGAlertView/LGAlertViewController.m
@@ -76,4 +76,8 @@
     return [UIApplication sharedApplication].statusBarStyle;
 }
 
+- (BOOL)prefersStatusBarHidden {
+    return [UIApplication sharedApplication].statusBarHidden;
+}
+
 @end


### PR DESCRIPTION
In some cases status bar could be hidden in current application state, it allows to preserve this state when new LGAlertView will be presented. It alters current behaviour, where status bar would appear again.