### PR TITLE
Added auto-deselection for buttons after 0.1s to mimic default behavior

### DIFF
--- a/LGAlertView/LGAlertView.m
+++ b/LGAlertView/LGAlertView.m
@@ -3124,6 +3124,10 @@ LGAlertViewType;
 - (void)cancelAction:(id)sender {
     if (sender && [sender isKindOfClass:[UIButton class]]) {
         [(UIButton *)sender setSelected:YES];
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [(UIButton *)sender setSelected:NO];
+        });
     }
 
     // -----
@@ -3158,6 +3162,10 @@ LGAlertViewType;
 - (void)destructiveAction:(id)sender {
     if (sender && [sender isKindOfClass:[UIButton class]]) {
         [(UIButton *)sender setSelected:YES];
+        
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [(UIButton *)sender setSelected:NO];
+        });
     }
 
     // -----
@@ -3226,6 +3234,10 @@ LGAlertViewType;
 - (void)firstButtonAction:(id)sender {
     if (sender && [sender isKindOfClass:[UIButton class]]) {
         [(UIButton *)sender setSelected:YES];
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [(UIButton *)sender setSelected:NO];
+        });
     }
 
     // -----
@@ -3242,6 +3254,10 @@ LGAlertViewType;
 - (void)secondButtonAction:(id)sender {
     if (sender && [sender isKindOfClass:[UIButton class]]) {
         [(UIButton *)sender setSelected:YES];
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [(UIButton *)sender setSelected:NO];
+        });
     }
 
     // -----
@@ -3258,6 +3274,10 @@ LGAlertViewType;
 - (void)thirdButtonAction:(id)sender {
     if (sender && [sender isKindOfClass:[UIButton class]]) {
         [(UIButton *)sender setSelected:YES];
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [(UIButton *)sender setSelected:NO];
+        });
     }
 
     // -----


### PR DESCRIPTION
Right now, with dismissOnAction set to false, the buttons get stuck with their highlight after touching. This is due to the workaround for UITableView touch delay by manually selecting them, but never deselecting.
This fix adds auto deselection for them after 0.1s.